### PR TITLE
fix: updated custom_data.sh.tpl to work with redhat disk device id's and resolve Azure CLI install issues on RHEL9

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,20 +53,20 @@ This module requires auto-unseal and defaults to the Azure Key Vault seal mechan
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.0 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [azurerm_dns_a_record.vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_a_record) | resource |
 | [azurerm_key_vault_access_policy.prereqs_kv_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_lb.vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb) | resource |
@@ -97,7 +97,7 @@ This module requires auto-unseal and defaults to the Azure Key Vault seal mechan
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_friendly_name_prefix"></a> [friendly\_name\_prefix](#input\_friendly\_name\_prefix) | Friendly name prefix for uniquely naming Azure resources. | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | Azure region for this Vault deployment. | `string` | n/a | yes |
 | <a name="input_prereqs_keyvault_name"></a> [prereqs\_keyvault\_name](#input\_prereqs\_keyvault\_name) | Name of the existing 'prereqs' Key Vault to use for prereqs Vault deployment, containing secrets for Vault license and TLS certs. | `string` | n/a | yes |
@@ -170,11 +170,13 @@ This module requires auto-unseal and defaults to the Azure Key Vault seal mechan
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_load_balancer_ip"></a> [load\_balancer\_ip](#output\_load\_balancer\_ip) | IP address of load balancer's frontend configuration |
 | <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | Name of the Resource Group. |
+| <a name="output_vault_address"></a> [vault\_address](#output\_vault\_address) | HTTPS address of the Vault cluster DNS name. |
 | <a name="output_vault_cli_config"></a> [vault\_cli\_config](#output\_vault\_cli\_config) | Environment variables to configure the Vault CLI |
 | <a name="output_vault_cluster_load_balancer_rule_id"></a> [vault\_cluster\_load\_balancer\_rule\_id](#output\_vault\_cluster\_load\_balancer\_rule\_id) | ID of the Vault cluster port (8201) load balancer rule. |
 | <a name="output_vault_cluster_probe_id"></a> [vault\_cluster\_probe\_id](#output\_vault\_cluster\_probe\_id) | ID of the dedicated Vault cluster port health probe. |
+| <a name="output_vault_fqdn"></a> [vault\_fqdn](#output\_vault\_fqdn) | FQDN of the Vault cluster (value for VAULT\_TLS\_SERVER\_NAME). |
 | <a name="output_vault_server_private_ips"></a> [vault\_server\_private\_ips](#output\_vault\_server\_private\_ips) | The Private IPs of the Vault servers that are spun up by VMSS |
 <!-- END_TF_DOCS -->

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -24,19 +24,19 @@ $ terraform apply
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.101 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_default_example"></a> [default\_example](#module\_default\_example) | ../.. | n/a |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_friendly_name_prefix"></a> [friendly\_name\_prefix](#input\_friendly\_name\_prefix) | Friendly name prefix for uniquely naming Azure resources. | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | Azure region for this Vault deployment. | `string` | n/a | yes |
 | <a name="input_prereqs_keyvault_name"></a> [prereqs\_keyvault\_name](#input\_prereqs\_keyvault\_name) | Name of the 'prereqs' Key Vault to use for prereqs Vault deployment. | `string` | n/a | yes |
@@ -109,6 +109,8 @@ $ terraform apply
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
+| <a name="output_vault_address"></a> [vault\_address](#output\_vault\_address) | HTTPS address of the Vault cluster. |
 | <a name="output_vault_cli_config"></a> [vault\_cli\_config](#output\_vault\_cli\_config) | n/a |
+| <a name="output_vault_fqdn"></a> [vault\_fqdn](#output\_vault\_fqdn) | FQDN of the Vault cluster (value for VAULT\_TLS\_SERVER\_NAME). |
 <!-- END_TF_DOCS -->

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -25,6 +25,7 @@ module "default_example" {
   create_resource_group = var.create_resource_group
   resource_group_name   = var.resource_group_name
   vault_fqdn            = var.vault_fqdn
+  vault_version         = var.vault_version
 
   #------------------------------------------------------------------------------
   # Networking
@@ -50,6 +51,14 @@ module "default_example" {
   #------------------------------------------------------------------------------
   enable_vault_cluster_port_listener = var.enable_vault_cluster_port_listener
   vm_ssh_public_key                  = var.vm_ssh_public_key
-  vmss_vm_count                      = 3
-  vm_sku                             = "Standard_D2s_v5"
+  vmss_vm_count                      = var.vmss_vm_count
+  vm_sku                             = var.vm_sku
+  vm_os_image                        = var.vm_os_image
+
+  #------------------------------------------------------------------------------
+  # DNS
+  #------------------------------------------------------------------------------
+  create_vault_public_dns_record = var.create_vault_public_dns_record
+  public_dns_zone_name           = var.public_dns_zone_name
+  public_dns_zone_rg             = var.public_dns_zone_rg
 }

--- a/examples/default/outputs.tf
+++ b/examples/default/outputs.tf
@@ -1,6 +1,16 @@
 # Copyright IBM Corp. 2024, 2025
 # SPDX-License-Identifier: MPL-2.0
 
+output "vault_address" {
+  description = "HTTPS address of the Vault cluster."
+  value       = module.default_example.vault_address
+}
+
+output "vault_fqdn" {
+  description = "FQDN of the Vault cluster (value for VAULT_TLS_SERVER_NAME)."
+  value       = module.default_example.vault_fqdn
+}
+
 output "vault_cli_config" {
   value = <<-EOF
     Set the following environment variables to configure the Vault CLI:

--- a/outputs.tf
+++ b/outputs.tf
@@ -36,6 +36,16 @@ output "vault_server_private_ips" {
   value       = data.azurerm_virtual_machine_scale_set.vault.instances.*.private_ip_address
 }
 
+output "vault_address" {
+  description = "HTTPS address of the Vault cluster DNS name."
+  value       = "https://${var.vault_fqdn}:8200"
+}
+
+output "vault_fqdn" {
+  description = "FQDN of the Vault cluster (value for VAULT_TLS_SERVER_NAME)."
+  value       = var.vault_fqdn
+}
+
 output "vault_cli_config" {
   description = "Environment variables to configure the Vault CLI"
   value       = <<-EOF

--- a/templates/custom_data.sh.tpl
+++ b/templates/custom_data.sh.tpl
@@ -89,9 +89,9 @@ function install_azcli() {
       curl -sL https://aka.ms/InstallAzureCLIDeb | bash
     elif [[ "$OS_DISTRO" == "rhel" || "$OS_DISTRO" == "centos" ]]; then
       log "INFO" "Installing Azure CLI for RHEL $OS_MAJOR_VERSION."
-			rpm --import https://packages.microsoft.com/keys/microsoft.asc
-      dnf install -y https://packages.microsoft.com/config/rhel/$OS_MAJOR_VERSION/packages-microsoft-prod.rpm
-      dnf install -y azure-cli
+      rpm --import https://packages.microsoft.com/keys/microsoft.asc
+      rpm -Uvh --quiet https://packages.microsoft.com/config/rhel/$OS_MAJOR_VERSION/packages-microsoft-prod.rpm
+      dnf install -y --disablerepo='*rhui*' --nobest azure-cli
     fi
   fi
 }
@@ -120,6 +120,7 @@ function prepare_disk() {
   local device_id=""
 
   for attempt in {1..12}; do
+    udevadm settle --timeout=5 >/dev/null 2>&1 || true
     for candidate in "$${candidate_paths[@]}"; do
       if [[ -e "$${candidate}" ]]; then
         device_id=$(readlink -f "$${candidate}")
@@ -130,6 +131,37 @@ function prepare_disk() {
     done
     sleep 5
   done
+
+  if [[ -z "$${device_id}" ]]; then
+    log "DEBUG" "prepare_disk - Azure disk symlink not found, falling back to lsblk scan."
+    # Two-pass scan:
+    #   Pass 1: first disk with no mounts AND no existing filesystem (fresh data disk).
+    #   Pass 2: first disk with no mounts but with a filesystem (handles previously-formatted
+    #           data disks; avoids selecting the OS disk which always has mounts).
+    # Root-on-LVM (common on RHEL 9) makes PKNAME lookups unreliable, so we use
+    # mountpoint presence as the only OS-disk signal.
+    local unmounted_formatted=""
+    while read -r candidate; do
+      [[ -z "$${candidate}" ]] && continue
+      # Skip any disk that has mounted filesystems (catches OS disk regardless of LVM/plain).
+      if lsblk -no MOUNTPOINT "$${candidate}" 2>/dev/null | grep -qv '^[[:space:]]*$'; then
+        continue
+      fi
+      if ! blkid "$${candidate}" &>/dev/null; then
+        # Unformatted, unmounted — ideal data disk candidate.
+        device_id="$${candidate}"
+        break
+      fi
+      # Formatted but unmounted — keep as fallback (temp disk may also match, so prefer above).
+      [[ -z "$${unmounted_formatted}" ]] && unmounted_formatted="$${candidate}"
+    done < <(lsblk -dpno NAME,TYPE | awk '$2 == "disk" { print $1 }')
+
+    # Fall back to first formatted-but-unmounted disk if no unformatted disk was found.
+    if [[ -z "$${device_id}" && -n "$${unmounted_formatted}" ]]; then
+      device_id="$${unmounted_formatted}"
+    fi
+  fi
+
   log "DEBUG" "prepare_disk - device_id; $${device_id}"
 	if [[ -z "$${device_id}" ]]; then
     log "ERROR" "No disk device found attached to device $${device_name}"
@@ -153,7 +185,7 @@ function install_packages() {
     apt-get update -y
     apt-get install -y $REQUIRED_PACKAGES $ADDITIONAL_PACKAGES
   elif [[ "$os_distro" == "centos" ]] || [[ "$os_distro" == "rhel" ]]; then
-    yum install -y $REQUIRED_PACKAGES $ADDITIONAL_PACKAGES
+    dnf install -y $REQUIRED_PACKAGES $ADDITIONAL_PACKAGES
   else
     log "ERROR" "Unable to determine package manager"
   fi


### PR DESCRIPTION
## Description
Fixes Red Hat deployment issues by improving Azure CLI installation and attached data disk detection in `custom_data.sh.tpl`. This PR also exposes Vault address/FQDN outputs and updates the default example to pass through configurable VM/image/DNS settings.

## Related issue
N/A

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

## How has this been tested?
- Verified changes by deploying the example for Ubuntu/RHEL.
- Confirmed output and example updates are consistent with module outputs/variables.

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
Primary fix targets Red Hat VMSS nodes where Azure data disk symlink discovery can fail. The fallback `lsblk`-based detection and package manager adjustments are intended to keep first boot and disk preparation reliable across supported Linux distributions.
