### PR TITLE
add redhat 10 VMSS OS

### DIFF
--- a/examples/default/variables.tf
+++ b/examples/default/variables.tf
@@ -402,8 +402,8 @@ variable "vm_os_image" {
   default     = "ubuntu2404"
 
   validation {
-    condition     = contains(["redhat8", "redhat9", "ubuntu2204", "ubuntu2404"], var.vm_os_image)
-    error_message = "Value must be one of 'redhat8', 'redhat9', 'ubuntu2204', or 'ubuntu2404'."
+    condition     = contains(["redhat8", "redhat9", "redhat10", "ubuntu2204", "ubuntu2404"], var.vm_os_image)
+    error_message = "Value must be one of 'redhat8', 'redhat9', 'redhat10', 'ubuntu2204', or 'ubuntu2404'."
   }
 }
 

--- a/image_data.tf
+++ b/image_data.tf
@@ -5,6 +5,7 @@ locals {
   os_image_map = {
     redhat8    = { publisher = "RedHat", offer = "RHEL" }
     redhat9    = { publisher = "RedHat", offer = "RHEL" }
+    redhat10   = { publisher = "RedHat", offer = "RHEL" }
     ubuntu2204 = { publisher = "Canonical", offer = "0001-com-ubuntu-server-jammy" }
     ubuntu2404 = { publisher = "Canonical", offer = "ubuntu-24_04-lts" }
   }
@@ -14,6 +15,7 @@ locals {
   vm_image_sku = (
     var.vm_os_image == "redhat8" ? "810-gen2" :
     var.vm_os_image == "redhat9" ? "95_gen2" :
+    var.vm_os_image == "redhat10" ? "10-lvm-gen2" :
     var.vm_os_image == "ubuntu2204" ? "22_04-lts-gen2" :
     var.vm_os_image == "ubuntu2404" ? "ubuntu-pro" : null
   )

--- a/variables.tf
+++ b/variables.tf
@@ -429,8 +429,8 @@ variable "vm_os_image" {
   default     = "ubuntu2404"
 
   validation {
-    condition     = contains(["redhat8", "redhat9", "ubuntu2204", "ubuntu2404"], var.vm_os_image)
-    error_message = "Value must be one of 'redhat8', 'redhat9', 'ubuntu2204', or 'ubuntu2404'."
+    condition     = contains(["redhat8", "redhat9", "redhat10", "ubuntu2204", "ubuntu2404"], var.vm_os_image)
+    error_message = "Value must be one of 'redhat8', 'redhat9', 'redhat10', 'ubuntu2204', or 'ubuntu2404'."
   }
 }
 


### PR DESCRIPTION
## Description
Adds support for Red Hat Enterprise Linux 10 (RHEL 10) as a valid OS image option for the Azure VMSS deployment. This includes the image publisher/offer mapping and the Gen2 LVM SKU (10-lvm-gen2) for RHEL 10, along with updated input validation in both the root module and the default example.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update

## How has this been tested?
- Ran `terraform validate` against the root module and `examples/default` — no errors.
- Verified the `redhat10` key maps correctly to `publisher = "RedHat"`, `offer = "RHEL"`, and SKU `10-lvm-gen2` in `image_data.tf`.
- Confirmed that validation blocks in `variables.tf` and `examples/default/variables.tf` now accept `"redhat10"` as a valid value without error.
- Deployed full stack, validated vault service starts and can be initialised.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional notes
The RHEL 10 image uses the `10-lvm-gen2` SKU from the `RedHat/RHEL` marketplace offer, consistent with how RHEL 8 (`810-gen2`) and RHEL 9 (`95_gen2`) are configured. 
No breaking changes, existing deployments using other OS images are unaffected.

