### PR TITLE
fix: cap azurerm provider version below 5.0 to prevent breaking changes

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.0"
+      version = ">= 3.0, < 5.0"
     }
   }
 }


### PR DESCRIPTION
## Description

Add an upper-bound constraint (`< 5.0`) to the `azurerm` provider version in `versions.tf` to prevent AzureRM 5.0 from being resolved. AzureRM 5.0 introduced breaking changes (removed/renamed arguments and new required blocks) that are incompatible with the current module code. This is an interim fix to protect users until the module is updated for full 5.0 compatibility.

## Related issue

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Ran `terraform init` and `terraform validate` against the existing examples with the updated constraint — no errors.
- Confirmed that `>= 3.0, < 5.0` correctly resolves to the latest 4.x provider and rejects 5.0.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
